### PR TITLE
Move the expand icon to the top of the skill card

### DIFF
--- a/main.css
+++ b/main.css
@@ -318,7 +318,7 @@ hr {
 .skills--main i {
   position: absolute;
   right: 1rem;
-  bottom: 1rem;
+  top: 1rem;
   text-align: right;
   opacity: 0.6;
   transition: opacity 200ms ease-out;

--- a/main.css
+++ b/main.css
@@ -321,7 +321,7 @@ hr {
   top: 1rem;
   text-align: right;
   opacity: 0.6;
-  transition: opacity 200ms ease-out;
+  transition: opacity 200ms ease-out 200ms;
 }
 
 .opacity {


### PR DESCRIPTION
Adjustments made to the skills section cards.  The icon to expand now sits at the top and a transition delay is added so the icons don't overlap upon fading in and out.